### PR TITLE
Pull local AWS account number if not provided in the account.hcl file.

### DIFF
--- a/terragrunt.hcl
+++ b/terragrunt.hcl
@@ -9,7 +9,7 @@ locals {
   environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
 
   # Extract the variables we need for easy access
-  account_id   = local.account_vars.locals.aws_account_id
+  account_id   = try(tonumber(local.account_vars.locals.aws_account_id),get_aws_account_id())
   aws_region   = local.region_vars.locals.aws_region
   aws_profile  = local.account_vars.locals.aws_profile
 }


### PR DESCRIPTION
Using the boilerplate `account.hcl` file renders this config repo inoperable for launching stacks. It would be best if users forked this and created their own environment config but for testing and ci purposes it would be nice if we could use this repo to launch new dev environments. 

This change will pull the current AWS account id and use that if none is provided.

Signed-off-by: David Della Vecchia <ddv@dozuki.com>