### PR TITLE
Add missing variables & 2.7.2 release

### DIFF
--- a/us-east-1/development/env.hcl
+++ b/us-east-1/development/env.hcl
@@ -28,6 +28,14 @@ locals {
   # Default: 0 (which will install latest sequence)
   #replicated_app_sequence_number = 0
 
+  # On fresh installs this variable specifies which channel to find the sequence indicated in `replicated_app_sequence_number`
+  # variable. This channel id must be associated to your customer account. If left blank the default channel id will be used.
+  #
+  # Note: This is NOT the channel name, but the UUID of the channel. This must be provided to you by Dozuki.
+  #
+  # Default: "" (which will look for the sequence in the default channel associated with your license)
+  #replicated_channel = ""
+
   # This option will spin up additional infrastructure to support webhooks. This includes an external AWS managed Kafka
   # cluster as well as redis and mongodb deployed onto the kubernetes cluster. Webhooks must be enabled on your license
   # before you enable this.
@@ -165,6 +173,7 @@ locals {
   #s3_images_bucket = ""
   #s3_documents_bucket = ""
   #s3_pdfs_bucket = ""
+  #s3_logging_bucket = ""
 
   # AWS KMS key identifier for RDS encryption. The identifier can be one of the following format: Key id, key ARN,
   # alias name or alias ARN

--- a/us-east-1/development/logical/terragrunt.hcl
+++ b/us-east-1/development/logical/terragrunt.hcl
@@ -2,7 +2,7 @@ skip = get_env("SKIP_LOGICAL", false)
 # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
 # working directory, into a temporary folder, and execute your Terraform commands in that folder.
 terraform {
-  source = "git::https://github.com/Dozuki/CloudPrem-Infra.git//cloudprem/logical?ref=v2.7.1"
+  source = "git::https://github.com/Dozuki/CloudPrem-Infra.git//cloudprem/logical?ref=v2.7.2"
 }
 
 # Include all settings from the root terragrunt.hcl file

--- a/us-east-1/development/physical/terragrunt.hcl
+++ b/us-east-1/development/physical/terragrunt.hcl
@@ -1,7 +1,7 @@
 # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
 # working directory, into a temporary folder, and execute your Terraform commands in that folder.
 terraform {
-  source = "git::https://github.com/Dozuki/CloudPrem-Infra.git//cloudprem/physical?ref=v2.7.1"
+  source = "git::https://github.com/Dozuki/CloudPrem-Infra.git//cloudprem/physical?ref=v2.7.2"
 }
 
 # Include all settings from the root terragrunt.hcl file

--- a/us-east-1/production/env.hcl
+++ b/us-east-1/production/env.hcl
@@ -28,6 +28,14 @@ locals {
   # Default: 0 (which will install latest sequence)
   #replicated_app_sequence_number = 0
 
+  # On fresh installs this variable specifies which channel to find the sequence indicated in `replicated_app_sequence_number`
+  # variable. This channel id must be associated to your customer account. If left blank the default channel id will be used.
+  #
+  # Note: This is NOT the channel name, but the UUID of the channel. This must be provided to you by Dozuki.
+  #
+  # Default: "" (which will look for the sequence in the default channel associated with your license)
+  #replicated_channel = ""
+
   # This option will spin up additional infrastructure to support webhooks. This includes an external AWS managed Kafka
   # cluster as well as redis and mongodb deployed onto the kubernetes cluster. Webhooks must be enabled on your license
   # before you enable this.
@@ -165,6 +173,7 @@ locals {
   #s3_images_bucket = ""
   #s3_documents_bucket = ""
   #s3_pdfs_bucket = ""
+  #s3_logging_bucket = ""
 
   # AWS KMS key identifier for RDS encryption. The identifier can be one of the following format: Key id, key ARN,
   # alias name or alias ARN

--- a/us-east-1/production/logical/terragrunt.hcl
+++ b/us-east-1/production/logical/terragrunt.hcl
@@ -2,7 +2,7 @@ skip = get_env("SKIP_LOGICAL", false)
 # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
 # working directory, into a temporary folder, and execute your Terraform commands in that folder.
 terraform {
-  source = "git::https://github.com/Dozuki/CloudPrem-Infra.git//cloudprem/logical?ref=v2.7.1"
+  source = "git::https://github.com/Dozuki/CloudPrem-Infra.git//cloudprem/logical?ref=v2.7.2"
 }
 
 # Include all settings from the root terragrunt.hcl file

--- a/us-east-1/production/physical/terragrunt.hcl
+++ b/us-east-1/production/physical/terragrunt.hcl
@@ -1,7 +1,7 @@
 # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
 # working directory, into a temporary folder, and execute your Terraform commands in that folder.
 terraform {
-  source = "git::https://github.com/Dozuki/CloudPrem-Infra.git//cloudprem/physical?ref=v2.7.1"
+  source = "git::https://github.com/Dozuki/CloudPrem-Infra.git//cloudprem/physical?ref=v2.7.2"
 }
 
 # Include all settings from the root terragrunt.hcl file

--- a/us-east-1/qa/env.hcl
+++ b/us-east-1/qa/env.hcl
@@ -28,6 +28,14 @@ locals {
   # Default: 0 (which will install latest sequence)
   #replicated_app_sequence_number = 0
 
+  # On fresh installs this variable specifies which channel to find the sequence indicated in `replicated_app_sequence_number`
+  # variable. This channel id must be associated to your customer account. If left blank the default channel id will be used.
+  #
+  # Note: This is NOT the channel name, but the UUID of the channel. This must be provided to you by Dozuki.
+  #
+  # Default: "" (which will look for the sequence in the default channel associated with your license)
+  #replicated_channel = ""
+
   # This option will spin up additional infrastructure to support webhooks. This includes an external AWS managed Kafka
   # cluster as well as redis and mongodb deployed onto the kubernetes cluster. Webhooks must be enabled on your license
   # before you enable this.
@@ -165,6 +173,7 @@ locals {
   #s3_images_bucket = ""
   #s3_documents_bucket = ""
   #s3_pdfs_bucket = ""
+  #s3_logging_bucket = ""
 
   # AWS KMS key identifier for RDS encryption. The identifier can be one of the following format: Key id, key ARN,
   # alias name or alias ARN

--- a/us-east-1/qa/logical/terragrunt.hcl
+++ b/us-east-1/qa/logical/terragrunt.hcl
@@ -2,7 +2,7 @@ skip = get_env("SKIP_LOGICAL", false)
 # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
 # working directory, into a temporary folder, and execute your Terraform commands in that folder.
 terraform {
-  source = "git::https://github.com/Dozuki/CloudPrem-Infra.git//cloudprem/logical?ref=v2.7.1"
+  source = "git::https://github.com/Dozuki/CloudPrem-Infra.git//cloudprem/logical?ref=v2.7.2"
 }
 
 # Include all settings from the root terragrunt.hcl file

--- a/us-east-1/qa/physical/terragrunt.hcl
+++ b/us-east-1/qa/physical/terragrunt.hcl
@@ -1,7 +1,7 @@
 # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
 # working directory, into a temporary folder, and execute your Terraform commands in that folder.
 terraform {
-  source = "git::https://github.com/Dozuki/CloudPrem-Infra.git//cloudprem/physical?ref=v2.7.1"
+  source = "git::https://github.com/Dozuki/CloudPrem-Infra.git//cloudprem/physical?ref=v2.7.2"
 }
 
 # Include all settings from the root terragrunt.hcl file


### PR DESCRIPTION
A variable for indicating an existing s3 logging bucket and targeting of the replicated channel were missing from this boilerplate config so I added those to all environments as well as updating the terragrunt config to pull v2.7.2 of the terraform infra.