### PR TITLE
Update config to reflect new S3 replication settings and new TF version targeting

### DIFF
--- a/common.hcl
+++ b/common.hcl
@@ -109,6 +109,8 @@ dependency "physical" {
     guide_objects_bucket = "dummy-objects-bucket"
     documents_bucket = "dummy-documents-bucket"
     guide_pdfs_bucket = "dummy-pdfs-bucket"
+    s3_kms_key_id = "dummy-kms-arn"
+    s3_replicate_buckets = "false"
     memcached_cluster_address = "dummy-memcache"
     dms_task_arn = "dummy-dms-arn"
     bi_database_credential_secret = "dummy-secret"
@@ -142,6 +144,8 @@ inputs = {
   s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
   s3_documents_bucket = dependency.physical.outputs.documents_bucket
   s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
+  s3_kms_key_id = dependency.physical.outputs.s3_kms_key_id
+  s3_replicate_buckets = dependency.physical.outputs.s3_replicate_buckets
   memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
   dms_task_arn = dependency.physical.outputs.dms_task_arn
   grafana_ssl_server_cert_parameter = dependency.physical.outputs.grafana_ssl_cert_parameter

--- a/us-east-1/development/env.hcl
+++ b/us-east-1/development/env.hcl
@@ -48,8 +48,8 @@ locals {
   # If deploying on a workstation, what AWSCLI credential profile should we use.
   # Note: This is not used if deploying using codepipeline & cloudformation.
   #
-  # Default: "default"
-  #aws_profile = "default"
+  # Default: ""
+  #aws_profile = ""
 
   # Google translate API token to support machine translation.
   #

--- a/us-east-1/development/env.hcl
+++ b/us-east-1/development/env.hcl
@@ -179,8 +179,8 @@ locals {
   #
   # It's imperative you keep the "type" values the same and only replace the donor bucket names with the actual values.
   #
-  # Default: ""
-  #s3_existing_buckets = ""
+  # Default: []
+  #s3_existing_buckets = []
 
   # AWS KMS key identifier for RDS encryption. The identifier can be one of the following format: Key id, key ARN,
   # alias name or alias ARN

--- a/us-east-1/development/env.hcl
+++ b/us-east-1/development/env.hcl
@@ -146,27 +146,41 @@ locals {
 
   # --- BEGIN Database and storage Options --- #
 
-  # AWS KMS key identifier for S3 encryption. The identifier can be one of the following format: Key id, key ARN, alias
+  # AWS KMS key identifier for S3 encryption used for migrations. The identifier can be one of the following format: Key id, key ARN, alias
   # name or alias ARN
   #
-  # Default: "alias/aws/s3"
-  #s3_kms_key_id = "alias/aws/s3"
-
-  # Whether to create the Dozuki S3 buckets or not. If this is set to false, you must specify the bucket names in the
-  # variables below.
+  # Note: This value is only used when migrating bucket contents from one stack to another. This is the donor buckets KMS Key.
   #
-  # Possible options: true, false
-  # Default: true
-  #create_s3_buckets = true
+  # Default: ""
+  #s3_kms_key_id = ""
 
   # If you have existing data in S3 buckets you can specify them here. These should be left blank if creating a fresh
-  # install. If setting these variables, be sure to set "create_s3_buckets" to false or these will be ignored.
+  # install.
   #
-  #s3_objects_bucket = ""
-  #s3_images_bucket = ""
-  #s3_documents_bucket = ""
-  #s3_pdfs_bucket = ""
-  #s3_logging_bucket = ""
+  # Note: This a list of objects with the following anatomy:
+  #  [
+  #    {
+  #      type        = "doc",
+  #      bucket_name = "doc-donor-bucket-name"
+  #    },
+  #    {
+  #      type        = "image",
+  #      bucket_name = "image-donor-bucket-name"
+  #    },
+  #    {
+  #      type        = "obj",
+  #      bucket_name = "object-donor-bucket-name"
+  #    },
+  #    {
+  #      type        = "pdf",
+  #      bucket_name = "pdf-donor-bucket-name"
+  #    }
+  #  ]
+  #
+  # It's imperative you keep the "type" values the same and only replace the donor bucket names with the actual values.
+  #
+  # Default: ""
+  #s3_existing_buckets = ""
 
   # AWS KMS key identifier for RDS encryption. The identifier can be one of the following format: Key id, key ARN,
   # alias name or alias ARN

--- a/us-east-1/development/logical/terragrunt.hcl
+++ b/us-east-1/development/logical/terragrunt.hcl
@@ -2,7 +2,7 @@ skip = get_env("SKIP_LOGICAL", false)
 # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
 # working directory, into a temporary folder, and execute your Terraform commands in that folder.
 terraform {
-  source = "git::https://github.com/Dozuki/CloudPrem-Infra.git//terraform/logical?ref=v3.1"
+  source = "git::https://github.com/Dozuki/CloudPrem-Infra.git//terraform/logical?ref=v3.2"
 }
 
 # Include all settings from the root terragrunt.hcl file

--- a/us-east-1/development/physical/terragrunt.hcl
+++ b/us-east-1/development/physical/terragrunt.hcl
@@ -1,7 +1,7 @@
 # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
 # working directory, into a temporary folder, and execute your Terraform commands in that folder.
 terraform {
-  source = "git::https://github.com/Dozuki/CloudPrem-Infra.git//terraform/physical?ref=v3.1"
+  source = "git::https://github.com/Dozuki/CloudPrem-Infra.git//terraform/physical?ref=v3.2"
 }
 
 # Include all settings from the root terragrunt.hcl file

--- a/us-east-1/production/env.hcl
+++ b/us-east-1/production/env.hcl
@@ -48,8 +48,8 @@ locals {
   # If deploying on a workstation, what AWSCLI credential profile should we use.
   # Note: This is not used if deploying using codepipeline & cloudformation.
   #
-  # Default: "default"
-  #aws_profile = "default"
+  # Default: ""
+  #aws_profile = ""
 
   # Google translate API token to support machine translation.
   #

--- a/us-east-1/production/env.hcl
+++ b/us-east-1/production/env.hcl
@@ -179,8 +179,8 @@ locals {
   #
   # It's imperative you keep the "type" values the same and only replace the donor bucket names with the actual values.
   #
-  # Default: ""
-  #s3_existing_buckets = ""
+  # Default: []
+  #s3_existing_buckets = []
 
   # AWS KMS key identifier for RDS encryption. The identifier can be one of the following format: Key id, key ARN,
   # alias name or alias ARN

--- a/us-east-1/production/env.hcl
+++ b/us-east-1/production/env.hcl
@@ -146,27 +146,41 @@ locals {
 
   # --- BEGIN Database and storage Options --- #
 
-  # AWS KMS key identifier for S3 encryption. The identifier can be one of the following format: Key id, key ARN, alias
+  # AWS KMS key identifier for S3 encryption used for migrations. The identifier can be one of the following format: Key id, key ARN, alias
   # name or alias ARN
   #
-  # Default: "alias/aws/s3"
-  #s3_kms_key_id = "alias/aws/s3"
-
-  # Whether to create the Dozuki S3 buckets or not. If this is set to false, you must specify the bucket names in the
-  # variables below.
+  # Note: This value is only used when migrating bucket contents from one stack to another. This is the donor buckets KMS Key.
   #
-  # Possible options: true, false
-  # Default: true
-  #create_s3_buckets = true
+  # Default: ""
+  #s3_kms_key_id = ""
 
   # If you have existing data in S3 buckets you can specify them here. These should be left blank if creating a fresh
-  # install. If setting these variables, be sure to set "create_s3_buckets" to false or these will be ignored.
+  # install.
   #
-  #s3_objects_bucket = ""
-  #s3_images_bucket = ""
-  #s3_documents_bucket = ""
-  #s3_pdfs_bucket = ""
-  #s3_logging_bucket = ""
+  # Note: This a list of objects with the following anatomy:
+  #  [
+  #    {
+  #      type        = "doc",
+  #      bucket_name = "doc-donor-bucket-name"
+  #    },
+  #    {
+  #      type        = "image",
+  #      bucket_name = "image-donor-bucket-name"
+  #    },
+  #    {
+  #      type        = "obj",
+  #      bucket_name = "object-donor-bucket-name"
+  #    },
+  #    {
+  #      type        = "pdf",
+  #      bucket_name = "pdf-donor-bucket-name"
+  #    }
+  #  ]
+  #
+  # It's imperative you keep the "type" values the same and only replace the donor bucket names with the actual values.
+  #
+  # Default: ""
+  #s3_existing_buckets = ""
 
   # AWS KMS key identifier for RDS encryption. The identifier can be one of the following format: Key id, key ARN,
   # alias name or alias ARN
@@ -195,7 +209,7 @@ locals {
   #
   # Possible options: true, false
   # Default: true
-  # rds_multi_az = true
+  #rds_multi_az = true
 
   # The initial size of the database storage allocated (in Gigabytes).
   #
@@ -291,6 +305,7 @@ locals {
   # Possible options: true or false
   # Default: true
   #grafana_use_replicated_ssl = true
+
 
   # The compute and memory capacity of the nodes in the Cache Cluster
   #

--- a/us-east-1/production/logical/terragrunt.hcl
+++ b/us-east-1/production/logical/terragrunt.hcl
@@ -2,7 +2,7 @@ skip = get_env("SKIP_LOGICAL", false)
 # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
 # working directory, into a temporary folder, and execute your Terraform commands in that folder.
 terraform {
-  source = "git::https://github.com/Dozuki/CloudPrem-Infra.git//terraform/logical?ref=v3.1"
+  source = "git::https://github.com/Dozuki/CloudPrem-Infra.git//terraform/logical?ref=v3.2"
 }
 
 # Include all settings from the root terragrunt.hcl file

--- a/us-east-1/production/physical/terragrunt.hcl
+++ b/us-east-1/production/physical/terragrunt.hcl
@@ -1,7 +1,7 @@
 # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
 # working directory, into a temporary folder, and execute your Terraform commands in that folder.
 terraform {
-  source = "git::https://github.com/Dozuki/CloudPrem-Infra.git//terraform/physical?ref=v3.1"
+  source = "git::https://github.com/Dozuki/CloudPrem-Infra.git//terraform/physical?ref=v3.2"
 }
 
 # Include all settings from the root terragrunt.hcl file

--- a/us-east-1/qa/env.hcl
+++ b/us-east-1/qa/env.hcl
@@ -48,8 +48,8 @@ locals {
   # If deploying on a workstation, what AWSCLI credential profile should we use.
   # Note: This is not used if deploying using codepipeline & cloudformation.
   #
-  # Default: "default"
-  #aws_profile = "default"
+  # Default: ""
+  #aws_profile = ""
 
   # Google translate API token to support machine translation.
   #

--- a/us-east-1/qa/env.hcl
+++ b/us-east-1/qa/env.hcl
@@ -179,8 +179,8 @@ locals {
   #
   # It's imperative you keep the "type" values the same and only replace the donor bucket names with the actual values.
   #
-  # Default: ""
-  #s3_existing_buckets = ""
+  # Default: []
+  #s3_existing_buckets = []
 
   # AWS KMS key identifier for RDS encryption. The identifier can be one of the following format: Key id, key ARN,
   # alias name or alias ARN

--- a/us-east-1/qa/env.hcl
+++ b/us-east-1/qa/env.hcl
@@ -146,27 +146,41 @@ locals {
 
   # --- BEGIN Database and storage Options --- #
 
-  # AWS KMS key identifier for S3 encryption. The identifier can be one of the following format: Key id, key ARN, alias
+  # AWS KMS key identifier for S3 encryption used for migrations. The identifier can be one of the following format: Key id, key ARN, alias
   # name or alias ARN
   #
-  # Default: "alias/aws/s3"
-  #s3_kms_key_id = "alias/aws/s3"
-
-  # Whether to create the Dozuki S3 buckets or not. If this is set to false, you must specify the bucket names in the
-  # variables below.
+  # Note: This value is only used when migrating bucket contents from one stack to another. This is the donor buckets KMS Key.
   #
-  # Possible options: true, false
-  # Default: true
-  #create_s3_buckets = true
+  # Default: ""
+  #s3_kms_key_id = ""
 
   # If you have existing data in S3 buckets you can specify them here. These should be left blank if creating a fresh
-  # install. If setting these variables, be sure to set "create_s3_buckets" to false or these will be ignored.
+  # install.
   #
-  #s3_objects_bucket = ""
-  #s3_images_bucket = ""
-  #s3_documents_bucket = ""
-  #s3_pdfs_bucket = ""
-  #s3_logging_bucket = ""
+  # Note: This a list of objects with the following anatomy:
+  #  [
+  #    {
+  #      type        = "doc",
+  #      bucket_name = "doc-donor-bucket-name"
+  #    },
+  #    {
+  #      type        = "image",
+  #      bucket_name = "image-donor-bucket-name"
+  #    },
+  #    {
+  #      type        = "obj",
+  #      bucket_name = "object-donor-bucket-name"
+  #    },
+  #    {
+  #      type        = "pdf",
+  #      bucket_name = "pdf-donor-bucket-name"
+  #    }
+  #  ]
+  #
+  # It's imperative you keep the "type" values the same and only replace the donor bucket names with the actual values.
+  #
+  # Default: ""
+  #s3_existing_buckets = ""
 
   # AWS KMS key identifier for RDS encryption. The identifier can be one of the following format: Key id, key ARN,
   # alias name or alias ARN

--- a/us-east-1/qa/logical/terragrunt.hcl
+++ b/us-east-1/qa/logical/terragrunt.hcl
@@ -2,7 +2,7 @@ skip = get_env("SKIP_LOGICAL", false)
 # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
 # working directory, into a temporary folder, and execute your Terraform commands in that folder.
 terraform {
-  source = "git::https://github.com/Dozuki/CloudPrem-Infra.git//terraform/logical?ref=v3.1"
+  source = "git::https://github.com/Dozuki/CloudPrem-Infra.git//terraform/logical?ref=v3.2"
 }
 
 # Include all settings from the root terragrunt.hcl file

--- a/us-east-1/qa/physical/terragrunt.hcl
+++ b/us-east-1/qa/physical/terragrunt.hcl
@@ -1,7 +1,7 @@
 # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
 # working directory, into a temporary folder, and execute your Terraform commands in that folder.
 terraform {
-  source = "git::https://github.com/Dozuki/CloudPrem-Infra.git//terraform/physical?ref=v3.1"
+  source = "git::https://github.com/Dozuki/CloudPrem-Infra.git//terraform/physical?ref=v3.2"
 }
 
 # Include all settings from the root terragrunt.hcl file


### PR DESCRIPTION
We no longer accept individual variables for each bucket and now require a composite map of bucket names and types so the config boilerplate has been updated to reflect this. 

Additionally I'm targeting terraform infra v3.2 in anticipation for that release.

We also forgot to pass through the s3 kms key Id to the app so the s3 upload functionality in the application was using the default kms key regardless of what was specified. This is now fixed as well.
